### PR TITLE
Improve fineliner rendering

### DIFF
--- a/src/rmc/exporters/writing_tools.py
+++ b/src/rmc/exporters/writing_tools.py
@@ -121,7 +121,10 @@ class Pen:
 class Fineliner(Pen):
     def __init__(self, base_width, base_color_id):
         super().__init__(base_width, base_color_id)
-        self.base_width = (base_width ** 2.1) * 1.3
+        if   base_width == 1: self.base_width = 1.5
+        elif base_width == 2: self.base_width = 4.0
+        elif base_width == 3: self.base_width = 6.0
+        else: self.base_width = (base_width ** 2.1) * 1.3
         self.name = "Fineliner"
 
 


### PR DESCRIPTION
Currently, fineliners are much thicker than the RM2 Web UI export. This PR resolves that:


Before [(pdf)](https://github.com/ricklupton/rmc/files/14554369/before.pdf):
![before](https://github.com/ricklupton/rmc/assets/9668927/37f49876-5f24-4c2b-80e4-9f74ba59cbf5)
After [(pdf)](https://github.com/ricklupton/rmc/files/14554366/after.pdf):
![after](https://github.com/ricklupton/rmc/assets/9668927/fdd9f7c1-3405-49a0-a4a4-45abff58396a)

RM2 Reference PDF:
[reference.pdf](https://github.com/ricklupton/rmc/files/14554365/reference.pdf)

