### PR TITLE
Fix typo in writing_tools.py

### DIFF
--- a/src/rmc/exporters/writing_tools.py
+++ b/src/rmc/exporters/writing_tools.py
@@ -112,7 +112,7 @@ class Pen:
             width = 12
             return Shader(width, color_id)
         # Erase area
-        elif pen_nr == PenType.ERASE_AREA:
+        elif pen_nr == PenType.ERASER_AREA:
             return EraseArea(width, color_id)
         # Eraser
         elif pen_nr == PenType.ERASER:


### PR DESCRIPTION
rmc crashing when converting to SVG. Traceback shows error "AttributeError: type object 'Pen' has no attribute 'ERASE_AREA'"