### PR TITLE
Added read/write support for image blobs

### DIFF
--- a/src/rmc/cli.py
+++ b/src/rmc/cli.py
@@ -117,6 +117,7 @@ def tree_structure(item):
 
 
 def convert_rm(filename: Path, to, fout):
+    image_path = filename.with_suffix("")
     with open(filename, "rb") as f:
         if to == "blocks":
             pprint_blocks(f, fout)
@@ -132,11 +133,11 @@ def convert_rm(filename: Path, to, fout):
             print_text(f, fout)
         elif to == "svg":
             tree = read_tree(f)
-            tree_to_svg(tree, fout)
+            tree_to_svg(tree, fout, image_path=image_path)
         elif to == "pdf":
             buf = io.StringIO()
             tree = read_tree(f)
-            tree_to_svg(tree, buf)
+            tree_to_svg(tree, buf, image_path=image_path)
             buf.seek(0)
             svg_to_pdf(buf, fout)
         else:

--- a/src/rmc/exporters/svg.py
+++ b/src/rmc/exporters/svg.py
@@ -7,6 +7,7 @@ https://github.com/chemag/maxio .
 import logging
 import string
 import typing as tp
+import base64
 from pathlib import Path
 
 from rmscene import CrdtId, SceneTree, read_tree
@@ -289,3 +290,18 @@ def draw_text(text: si.Text, output):
                 output.write(f'\t\t\t<!-- Text line char_id: {p.start_id} -->\n')
             output.write(f'\t\t\t<text x="{xx(xpos)}" y="{yy(ypos)}" class="{cls}">{str(p).strip()}</text>\n')
     output.write('\t\t</g>\n')
+
+
+def draw_image(image: si.Image, output, image_path: Path | None = None):
+    left = image.vertices[0]
+    top = image.vertices[1]
+    right = image.vertices[4]
+    bottom = image.vertices[9]
+
+    height = bottom - top
+    width = right - left
+
+    href = base64.b64encode((image_path / image.filename).read_bytes()).decode()
+    output.write(f'\t\t<g transform="translate({xx(left)}, {yy(top)})">\n\n')
+    output.write(f'\t\t<image height="{yy(height)}" width="{xx(width)}" href="data:image/png;base64,{href}"/>\n\n')
+    output.write(f'\t\t</g>')

--- a/src/rmc/exporters/svg.py
+++ b/src/rmc/exporters/svg.py
@@ -63,6 +63,7 @@ SVG_HEADER = string.Template("""<?xml version="1.0" encoding="UTF-8"?>
 
 def rm_to_svg(rm_path, svg_path):
     """Convert `rm_path` to SVG at `svg_path`."""
+    image_path = Path(rm_path).with_suffix("")
     with open(rm_path, "rb") as infile, open(svg_path, "wt") as outfile:
         tree = read_tree(infile)
         tree_to_svg(tree, outfile)
@@ -73,7 +74,7 @@ def read_template_svg(template_path: Path) -> str:
     return "\n".join(lines[2:-2])
 
 
-def tree_to_svg(tree: SceneTree, output, include_template: Path | None = None):
+def tree_to_svg(tree: SceneTree, output, include_template: Path | None = None, image_path: Path | None = None):
     """Convert Blocks to SVG."""
 
     # find the anchor pos for further use
@@ -102,7 +103,7 @@ def tree_to_svg(tree: SceneTree, output, include_template: Path | None = None):
     if tree.root_text is not None:
         draw_text(tree.root_text, output)
 
-    draw_group(tree.root, output, anchor_pos)
+    draw_group(tree.root, output, anchor_pos, image_path=image_path)
 
     # Closing page group
     output.write('\t</g>\n')
@@ -191,7 +192,7 @@ def get_bounding_box(item: si.Group,
     return x_min, x_max, y_min, y_max
 
 
-def draw_group(item: si.Group, output, anchor_pos):
+def draw_group(item: si.Group, output, anchor_pos, image_path: Path | None = None):
     anchor_x, anchor_y = get_anchor(item, anchor_pos)
     output.write(f'\t\t<g id="{item.node_id}" transform="translate({xx(anchor_x)}, {yy(anchor_y)})">\n')
     for child_id in item.children:
@@ -200,9 +201,11 @@ def draw_group(item: si.Group, output, anchor_pos):
         if _logger.root.level == logging.DEBUG:
             output.write(f'\t\t<!-- child {child_id} {type(child)} -->\n')
         if isinstance(child, si.Group):
-            draw_group(child, output, anchor_pos)
+            draw_group(child, output, anchor_pos, image_path=image_path)
         elif isinstance(child, si.Line):
             draw_stroke(child, output)
+        elif isinstance(child, si.Image):
+            draw_image(child, output, image_path=image_path)
     output.write(f'\t\t</g>\n')
 
 


### PR DESCRIPTION
This adds support for the native image insertions in notebooks on [3.27 or later](https://support.remarkable.com/s/article/Software-Release-3-27). This is the companion to ricklupton/rmscene#52.

In order to find the images to be included, this passes an image base path around that is [inferred in `convert_rm`](https://github.com/yannickulrich/rmc/blob/c883330cb86543a3425e402a255b77e5ec1fa1d7/src/rmc/cli.py#L120)
```python
def convert_rm(filename: Path, to, fout):
    image_path = filename.with_suffix("")
```
